### PR TITLE
Dynamically read setup.py meta from package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,46 @@
 Setup script for PyPi
 """
 import codecs
+import re
 from setuptools import setup
 
-import random_useragent
 
 # Get the long description from the relevant file
 with codecs.open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
+
+# Open the package file so we can read the meta data.
+with codecs.open('random_useragent.py', encoding='utf-8') as f:
+    package_file = f.read()
+
+
+def get_package_meta(meta_name):
+    """Return value of variable set in the package where said variable is
+    named in the Python meta format `__<meta_name>__`.
+    """
+    regex = "__{0}__ = ['\"]([^'\"]+)['\"]".format(meta_name)
+    return re.search(regex, package_file).group(1)
+
+
+version = get_package_meta('version')
+author = get_package_meta('author')
+email = get_package_meta('email')
+license = get_package_meta('license')
+
+
 setup(
     name='scrapy-random-useragent',
-    version=random_useragent.__version__,
+    version=version,
 
     description='Scrapy Middleware to set a random User-Agent for every Request.',
     long_description=long_description,
 
-    author=random_useragent.__author__,
-    author_email=random_useragent.__email__,
+    author=author,
+    author_email=email,
     url='https://github.com/cnu/scrapy-random-useragent',
 
-    license=random_useragent.__license__,
+    license=license,
 
     py_modules=['random_useragent'],
     platforms=['Any'],


### PR DESCRIPTION
Importing the project module itself requires that `scrapy` be installed
before this package can be installed by easy_install or pip due to it
being a dependency of the main module.

That action breaks common build patterns where `scrapy` &
`scrapy-random-useragent` are installed at the same time. See
the ticket for more information.

The fix here is to simply open the package file in setup.py and take the
variables we need directly out of it; this solution means we can keep
things DRY and don't have to repeat meta & version information across
the project.

Fixes #2.