### PR TITLE
Fixing scrapy warning

### DIFF
--- a/random_useragent.py
+++ b/random_useragent.py
@@ -8,7 +8,7 @@ user-agents and sets a random one for each request.
 
 import random
 from scrapy import signals
-from scrapy.contrib.downloadermiddleware.useragent import UserAgentMiddleware
+from scrapy.downloadermiddlewares.useragent import UserAgentMiddleware
 
 __author__ = "Srinivasan Rangarajan"
 __copyright__ = "Copyright 2014, Srinivasan Rangarajan"


### PR DESCRIPTION
2016-06-10 22:07:41 [py.warnings] WARNING: /lib/python2.7/site-packages/random_useragent.py:11: ScrapyDeprecationWarning: Module `scrapy.contrib.downloadermiddleware.useragent` is deprecated, use `scrapy.downloadermiddlewares.useragent` instead
  from scrapy.contrib.downloadermiddleware.useragent import UserAgentMiddleware